### PR TITLE
Allow defining WF_LZ_NO_UNALIGNED_ACCESS to disable unaligned accesses

### DIFF
--- a/wfLZ.c
+++ b/wfLZ.c
@@ -19,7 +19,7 @@
 // when using ChunkCompress() each block will be aligned to this -- makes PS3 SPU transfer convenient
 #define WFLZ_CHUNK_PAD 16
 
-#ifndef SPU
+#if !defined(SPU) && !defined(WF_LZ_NO_UNALIGNED_ACCESS)
 	#define WF_LZ_UNALIGNED_ACCESS
 #endif
 


### PR DESCRIPTION
This is really just a workaround for #4, but it's probably not a bad idea even after that is resolved.  Unaligned access is undefined behavior, after all…
